### PR TITLE
Dashboard cleanup

### DIFF
--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -1723,9 +1723,9 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000052">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000114"/>
-        <obo:IAO_0000115 xml:lang="en">A committee with members from multiple specialties that engages in case review of trauma cases.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A committee that engages in case review of trauma cases.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
-        <obo:OOSTT_00000030 xml:lang="en">A committee with members from multiple specialties that engages in case review of trauma care.</obo:OOSTT_00000030>
+        <obo:OOSTT_00000030 xml:lang="en">A committee that engages in case review of trauma care.</obo:OOSTT_00000030>
         <rdfs:label xml:lang="en">trauma peer review committee</rdfs:label>
     </owl:Class>
     
@@ -3566,7 +3566,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
-        <obo:IAO_0000115 xml:lang="en">An aggregate of organizations whose members are all bearer of a level 1 trauma center role.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An aggregate of organizations whose members are all bearer of a level 2 trauma center role.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <obo:OOSTT_00000030 xml:lang="en">A group of healthcare facilities that are all ACS verified or state designated as level 2 trauma centers.</obo:OOSTT_00000030>
         <rdfs:label xml:lang="en">aggregate of level 2 trauma centers</rdfs:label>
@@ -6906,7 +6906,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
-        <obo:IAO_0000115 xml:lang="en">An aggregate of organization that consists only of emergencny medical service pediatric ground transportation agencies.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An aggregate of organization that consists only of emergencny medical service pediatric air transportation agencies.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">aggregate of emergency medical services pediatric air transportation agencies</rdfs:label>
     </owl:Class>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -346,7 +346,7 @@ https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000145">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/GEO_000000372"/>
-        <obo:IAO_0000115 xml:lang="en">&apos;services area&apos; holds iff a an organization performing or organizing paid or unpaid planned processes that benefit 3rd parties and b is a geographical region and a performs or organizes said planned process in the site of b.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">&apos;Services area&apos; holds iff a an organization performing or organizing paid or unpaid planned processes that benefit 3rd parties and b is a geographical region and a performs or organizes said planned process in the site of b.</obo:IAO_0000115>
         <obo:IAO_0000117>Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">services geographical region</rdfs:label>
     </owl:ObjectProperty>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -6443,7 +6443,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
                         <owl:someValuesFrom>
                             <owl:Class>
                                 <owl:intersectionOf rdf:parseType="Collection">
-                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0021032"/>
+                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0021013"/>
                                     <owl:Restriction>
                                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000052"/>
                                         <owl:someValuesFrom>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -6903,7 +6903,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
             </owl:intersectionOf>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
-        <obo:IAO_0000115 xml:lang="en">An aggregate of organization that consists only of emergencny medical service pediatric ground transportation agencies.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An aggregate of organization that consists only of emergency medical service pediatric ground transportation agencies.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">aggregate of emergency medical services pediatric ground transportation agencies</rdfs:label>
     </owl:Class>
@@ -6923,7 +6923,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
             </owl:intersectionOf>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
-        <obo:IAO_0000115 xml:lang="en">An aggregate of organization that consists only of emergencny medical service pediatric air transportation agencies.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An aggregate of organization that consists only of emergency medical service pediatric air transportation agencies.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">aggregate of emergency medical services pediatric air transportation agencies</rdfs:label>
     </owl:Class>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -29,6 +29,7 @@
         <dc:contributor xml:lang="en">Stephen M. Bowman</dc:contributor>
         <dc:contributor xml:lang="en">William R. Hogan</dc:contributor>
         <dc:creator xml:lang="en">Mathias Brochhausen</dc:creator>
+        <dc:description>The Ontology of Organizational Structures of Trauma centers and Trauma systems (OOSTT) is a representation of the components of trauma centers and trauma systems coded in Web Ontology Language (OWL2).</dc:description>
         <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
         <dc:title xml:lang="en">Ontology of Organizational Structures of Trauma centers and Trauma Systems</dc:title>
         <rdfs:comment xml:lang="en">Development of this ontology is funded by a grant from the National Institute of General Medical Sciences of the National Institutes of Health.</rdfs:comment>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -297,7 +297,7 @@ https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000056"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/>
-        <obo:IAO_0000115 xml:lang="en">&apos;organize&apos; holds between an independent continuant and a planned process, iff the independent continuant particpates in the planned process and also participated in the creation of the plan specification that the planned process realizes.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">&apos;Organize&apos; holds between an independent continuant and a planned process, iff the independent continuant particpates in the planned process and also participated in the creation of the plan specification that the planned process realizes.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">organize</rdfs:label>
     </owl:ObjectProperty>
@@ -334,7 +334,7 @@ https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_
         <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000278"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/IAO_0000033"/>
-        <obo:IAO_0000115 xml:lang="en">&apos;has policy&apos; holds between an organization and a directive information entity, iff the directive information entity is the outcome of a document act and it is meant to regulate the actions of the organization or its organizational members.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">&apos;Has policy&apos; holds between an organization and a directive information entity, iff the directive information entity is the outcome of a document act and it is meant to regulate the actions of the organization or its organizational members.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">has policy</rdfs:label>
     </owl:ObjectProperty>
@@ -356,7 +356,7 @@ https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_
     <!-- http://purl.obolibrary.org/obo/OOSTT_00000278 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000278">
-        <obo:IAO_0000115 xml:lang="en">&apos;policy of&apos; holds between a directive information entity and an organization iff the directive information entity is the outcome of a document act and it is meant to regulate the actions of the organization or its organizational members.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">&apos;Policy of&apos; holds between a directive information entity and an organization iff the directive information entity is the outcome of a document act and it is meant to regulate the actions of the organization or its organizational members.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">policy of</rdfs:label>
     </owl:ObjectProperty>
@@ -2495,7 +2495,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000100">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0021004"/>
-        <obo:IAO_0000115 xml:lang="en">a socio-legal generically dependent continuant that is concretized in a role within an organizational context and which legally, normatively, or ethically permits some action.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A socio-legal generically dependent continuant that is concretized in a role within an organizational context and which legally, normatively, or ethically permits some action.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">J. Neil Otte</obo:IAO_0000117>
         <rdfs:label xml:lang="en">authority</rdfs:label>
     </owl:Class>
@@ -2506,7 +2506,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000101">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000100"/>
-        <obo:IAO_0000115 xml:lang="en">authority prescribed by some enabling legislation</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">Authority prescribed by some enabling legislation</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">J. Neil Otte</obo:IAO_0000117>
         <obo:OOSTT_00000030 xml:lang="en">Authority prescribed by enabling legislation, rules, or regulations</obo:OOSTT_00000030>
         <rdfs:label xml:lang="en">statutory authority</rdfs:label>
@@ -2664,7 +2664,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000110">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000111"/>
-        <obo:IAO_0000115 xml:lang="en">a governmental organization that has the authority to create, amend, fund, and repeal laws.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A governmental organization that has the authority to create, amend, fund, and repeal laws.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">J. Neil Otte</obo:IAO_0000117>
         <rdfs:label xml:lang="en">legislature</rdfs:label>
     </owl:Class>
@@ -2714,7 +2714,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
                 </owl:allValuesFrom>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:IAO_0000115 xml:lang="en">an organization consisting of persons who bear committee member role where that organization is appointed by an organization or members of an organization to realize a role.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An organization consisting of persons who bear committee member role where that organization is appointed by an organization or members of an organization to realize a role.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">J. Neil Otte</obo:IAO_0000117>
         <obo:OOSTT_00000030 xml:lang="en">A group of individuals appointed by an organization or organization leader to complete a specific task or to fulfill a specific set of responsibilities.</obo:OOSTT_00000030>
         <rdfs:comment xml:lang="en">Dec 10, 2016: The definition originally stated that the committee was realizing a function. After review of the BFO definition of function I decided to change it to &quot;role&quot;. M. Brochhausen</rdfs:comment>
@@ -2727,7 +2727,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000115">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000114"/>
-        <obo:IAO_0000115 xml:lang="en">a committee whose function is to evaluate the system of care within a trauma center.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A committee whose function is to evaluate the system of care within a trauma center.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">J. Neil Otte</obo:IAO_0000117>
         <obo:IAO_0000117 xml:lang="en">Sarah Bost</obo:IAO_0000117>
         <obo:OOSTT_00000030 xml:lang="en">A committee whose function is to evaluate and recommend improvements to the quality of the system of care within a trauma center or trauma system.</obo:OOSTT_00000030>
@@ -2753,7 +2753,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
                 </owl:someValuesFrom>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:IAO_0000115 xml:lang="en">a role that inheres in a homo sapiens that, if realized, is realized by preparing, keeping, and overseeing records made in a register.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A role that inheres in a homo sapiens that, if realized, is realized by preparing, keeping, and overseeing records made in a register.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Jonathan Bona</obo:IAO_0000117>
         <obo:IAO_0000117 xml:lang="en">Neil J. Otte</obo:IAO_0000117>
         <obo:OOSTT_00000030 xml:lang="en">An individual who abstract(s) and record(s) data into an electronic registry .</obo:OOSTT_00000030>
@@ -2766,7 +2766,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000117">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
-        <obo:IAO_0000115 xml:lang="en">a role that, if realized, is realized in the organization context of a committee.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A role that, if realized, is realized in the organization context of a committee.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Neil J Otte</obo:IAO_0000117>
         <obo:OOSTT_00000030 xml:lang="en">The duties and responsibilities assigned to the member(s) of a committee.</obo:OOSTT_00000030>
         <rdfs:label xml:lang="en">committee member role</rdfs:label>
@@ -2778,7 +2778,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000118">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000016"/>
-        <obo:IAO_0000115 xml:lang="en">a disposition realized in process profiles that have participants the biological qualities of patients and the practices and instruments of medical professionals.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A disposition realized in process profiles that have participants the biological qualities of patients and the practices and instruments of medical professionals.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Neil J. Otte</obo:IAO_0000117>
         <obo:OOSTT_00000030 xml:lang="en">An organizational approach to patient care that reduces or mitigates the risk for untoward patient outcomes.</obo:OOSTT_00000030>
         <rdfs:label xml:lang="en">patient safety</rdfs:label>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -6461,7 +6461,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
                         <owl:someValuesFrom>
                             <owl:Class>
                                 <owl:intersectionOf rdf:parseType="Collection">
-                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0021013"/>
+                                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0021016"/>
                                     <owl:Restriction>
                                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000052"/>
                                         <owl:someValuesFrom>
@@ -6484,7 +6484,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0021001"/>
-        <obo:IAO_0000115 xml:lang="en">A document act that has as specified its output obligor roles that are borne a trauma system or its organizational members and that are specified in a directive information content entity that is policy of that trauma system.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A deontic document act that has as specified its output duty holder roles that are borne a trauma system or its organizational members and that are specified in a directive information content entity that is policy of that trauma system.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">ratifying regulations for trauma system</rdfs:label>
     </owl:Class>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -4669,6 +4669,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
     <!-- http://purl.obolibrary.org/obo/OOSTT_00000201 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000201">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000023"/>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -3085,7 +3085,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
                 <owl:someValuesFrom>
                     <owl:Restriction>
                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000059"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000133"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000375"/>
                     </owl:Restriction>
                 </owl:someValuesFrom>
             </owl:Restriction>
@@ -7776,6 +7776,18 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
         <obo:OOSTT_00000030 xml:lang="en">The individual with authority and responsibility for evaluating the nursing care provided to trauma patients.</obo:OOSTT_00000030>
         <obo:OOSTT_00000324 xml:lang="en">trauma nursing evaluator</obo:OOSTT_00000324>
         <rdfs:label xml:lang="en">trauma nursing evaluator obligor role</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OOSTT_00000375 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000375">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000104"/>
+        <obo:IAO_0000115 xml:lang="en">A plan specification that specifies on which schedule and to which extent anesthesia services are provided within a healthcare provider organization.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
+        <obo:OOSTT_00000030 xml:lang="en">A plan that specifies the schedule for ensuring adequate numbers of  anesthesia care providers are readily available 24 hours a day 7 days a week within a trauma center.</obo:OOSTT_00000030>
+        <rdfs:label xml:lang="en">anesthesia services availability plan specification</rdfs:label>
     </owl:Class>
     
 

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -2304,7 +2304,6 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000013"/>
         <obo:IAO_0000115 xml:lang="en">A physician role borne by a human being and that, if realized, is being realized by its bearer using operative manual and instrumental techniques on a patient to investigate or treat a pathological condition such as disease or injury, to help improve bodily function or appearance or to repair unwanted ruptured areas.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
-        <obo:IAO_0000118 xml:lang="en">general surgeon role</obo:IAO_0000118>
         <obo:OOSTT_00000030 xml:lang="en">A physician who specializes in performing operative manual and instrumental techniques on a patient to investigate or treat a pathological condition such as disease or injury or congenital defect, to help improve bodily function or appearance, or to repair ruptured areas.</obo:OOSTT_00000030>
         <rdfs:comment xml:lang="en">term requested in OMRSE. Do not use outside the CAFE application!</rdfs:comment>
         <rdfs:label xml:lang="en">surgeon role</rdfs:label>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -1747,10 +1747,13 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000054">
         <owl:equivalentClass>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000299"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000159"/>
-            </owl:Restriction>
+            <owl:intersectionOf rdf:parseType="Collection">
+                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000011"/>
+                <owl:Restriction>
+                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000299"/>
+                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000159"/>
+                </owl:Restriction>
+            </owl:intersectionOf>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/>
         <obo:IAO_0000115 xml:lang="en">A planned process that has prehospital protocols as its specified output.</obo:IAO_0000115>
@@ -3695,10 +3698,13 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000166">
         <owl:equivalentClass>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000167"/>
-            </owl:Restriction>
+            <owl:intersectionOf rdf:parseType="Collection">
+                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/>
+                <owl:Restriction>
+                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000167"/>
+                </owl:Restriction>
+            </owl:intersectionOf>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
         <rdfs:subClassOf>
@@ -4969,10 +4975,13 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000212">
         <owl:equivalentClass>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000211"/>
-            </owl:Restriction>
+            <owl:intersectionOf rdf:parseType="Collection">
+                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000288"/>
+                <owl:Restriction>
+                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000211"/>
+                </owl:Restriction>
+            </owl:intersectionOf>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000288"/>
         <obo:IAO_0000115 xml:lang="en">An information content entity that is the specified output of a critical care certificate course.</obo:IAO_0000115>
@@ -5043,10 +5052,13 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000215">
         <owl:equivalentClass>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000214"/>
-            </owl:Restriction>
+            <owl:intersectionOf rdf:parseType="Collection">
+                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/>
+                <owl:Restriction>
+                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000214"/>
+                </owl:Restriction>
+            </owl:intersectionOf>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
         <rdfs:subClassOf>
@@ -5645,10 +5657,13 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000233">
         <owl:equivalentClass>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000232"/>
-            </owl:Restriction>
+            <owl:intersectionOf rdf:parseType="Collection">
+                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/>
+                <owl:Restriction>
+                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000232"/>
+                </owl:Restriction>
+            </owl:intersectionOf>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
         <rdfs:subClassOf>
@@ -6766,10 +6781,13 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000296">
         <owl:equivalentClass>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000075"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000292"/>
-            </owl:Restriction>
+            <owl:intersectionOf rdf:parseType="Collection">
+                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
+                <owl:Restriction>
+                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000075"/>
+                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000292"/>
+                </owl:Restriction>
+            </owl:intersectionOf>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
         <obo:IAO_0000115 xml:lang="en">An aggregate of emergency medical services agencies that provide transport for the sick and injured.</obo:IAO_0000115>
@@ -6884,10 +6902,13 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000304">
         <owl:equivalentClass>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000075"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000302"/>
-            </owl:Restriction>
+            <owl:intersectionOf rdf:parseType="Collection">
+                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
+                <owl:Restriction>
+                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000075"/>
+                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000302"/>
+                </owl:Restriction>
+            </owl:intersectionOf>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
         <obo:IAO_0000115 xml:lang="en">An aggregate of organization that consists only of emergencny medical service pediatric ground transportation agencies.</obo:IAO_0000115>
@@ -6901,10 +6922,13 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000305">
         <owl:equivalentClass>
-            <owl:Restriction>
-                <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000075"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000303"/>
-            </owl:Restriction>
+            <owl:intersectionOf rdf:parseType="Collection">
+                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
+                <owl:Restriction>
+                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000075"/>
+                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000303"/>
+                </owl:Restriction>
+            </owl:intersectionOf>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
         <obo:IAO_0000115 xml:lang="en">An aggregate of organization that consists only of emergencny medical service pediatric air transportation agencies.</obo:IAO_0000115>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -244,14 +244,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0020012 -->
-
-    <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0020012">
-        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
-    </owl:ObjectProperty>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/OBI_0000846 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000846">

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -167,6 +167,7 @@
     <!-- http://purl.obolibrary.org/obo/OOSTT_00000030 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000030">
+        <obo:IAO_0000115 xml:lang="en">A description of an OOSTT class that is aimed at the OOSTT user community and not meant to be definition for use in ontology development, curation or maintenance.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">OOSTT user-centered description</rdfs:label>
     </owl:AnnotationProperty>
@@ -314,6 +315,7 @@ https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000113">
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000136"/>
+        <obo:IAO_0000115 xml:lang="en">A primitive, instance-level, relation obtaining between an information content entity and some portion of reality. Prescribing is what happens when an information content entity created, ratified, or issued by an entity with authority over the domain the ICE targets states actions or specifications or the omission of actions that are expected to be adhered to.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Neil J. Otte</obo:IAO_0000117>
         <rdfs:label xml:lang="en">prescribes</rdfs:label>
     </owl:ObjectProperty>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -4914,7 +4914,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
                     </owl:Class>
                     <owl:Restriction>
                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000208"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000372"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
@@ -5482,7 +5482,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
                     </owl:Class>
                     <owl:Restriction>
                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000208"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000372"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
@@ -5522,7 +5522,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
                     </owl:Class>
                     <owl:Restriction>
                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0000053"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000208"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000372"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -2690,6 +2690,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
         <owl:disjointWith rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000272"/>
         <obo:IAO_0000115 xml:lang="en">An organization that is a part of some government.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">J. Neil Otte</obo:IAO_0000117>
+        <obo:IAO_0000118 xml:lang="en">government organization</obo:IAO_0000118>
         <obo:IAO_0000119>Derived from 18 U.S. Code § 2711. Accessed 12.4.2022 at https://www.law.cornell.edu/uscode/text/18/2711#4</obo:IAO_0000119>
         <rdfs:label xml:lang="en">governmental organization</rdfs:label>
     </owl:Class>
@@ -2937,7 +2938,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
         <obo:IAO_0000115 xml:lang="en">An organization with a specific responsibility that is a part of a larger organization with a specific responsibility.</obo:IAO_0000115>
         <obo:IAO_0000119 xml:lang="en">http://en.wikipedia.org/wiki/Department</obo:IAO_0000119>
         <obo:OOSTT_00000030>A formal subdivision of an organization with a specific responsibility.</obo:OOSTT_00000030>
-        <rdfs:comment xml:lang="en">This class does not contain government departments. Government department is to be found here: http://purl.obolibrary.org/obo/OOSTT_00000274 MB, Jan 4, 2017</rdfs:comment>
+        <rdfs:comment xml:lang="en">This class does not contain governmental departments. Governmental department is to be found here: http://purl.obolibrary.org/obo/OOSTT_00000274 MB, Jan 4, 2017</rdfs:comment>
         <rdfs:label xml:lang="en">department</rdfs:label>
     </owl:Class>
     
@@ -6327,8 +6328,9 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000270"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:IAO_0000115 xml:lang="en">An organization that is part of the machinery of government and that is responsible for the oversight and administration of specific functions. The government agencies are given the authority to fulfill those responsibilities by the government.</obo:IAO_0000115>
-        <rdfs:label xml:lang="en">government agency</rdfs:label>
+        <obo:IAO_0000115 xml:lang="en">An organization that is part of the machinery of government and that is responsible for the oversight and administration of specific functions. The governmental agencies are given the authority to fulfill those responsibilities by the government.</obo:IAO_0000115>
+        <obo:IAO_0000118 xml:lang="en">government agency</obo:IAO_0000118>
+        <rdfs:label xml:lang="en">governmental agency</rdfs:label>
     </owl:Class>
     
 
@@ -6361,9 +6363,10 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
-        <obo:IAO_0000115 xml:lang="en">An organization that is not a government agency, not an organizational member of the machinery of government, and not part of the government.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">An organization that is not a governmental agency, not an organizational member of the machinery of government, and not part of the government.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
-        <rdfs:label xml:lang="en">non-government organization</rdfs:label>
+        <obo:IAO_0000118 xml:lang="en">non-government organization</obo:IAO_0000118>
+        <rdfs:label xml:lang="en">non-governmental organization</rdfs:label>
     </owl:Class>
     
 
@@ -6390,9 +6393,10 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000271"/>
-        <obo:IAO_0000115 xml:lang="en">A government agency that is not reporting to any specific departmental part of government.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A governmental agency that is not reporting to any specific departmental part of government.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
-        <rdfs:label xml:lang="en">free-standing government agency</rdfs:label>
+        <obo:IAO_0000118 xml:lang="en">free-standing government agency</obo:IAO_0000118>
+        <rdfs:label xml:lang="en">free-standing governmental agency</rdfs:label>
     </owl:Class>
     
 
@@ -6411,8 +6415,9 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
         <obo:IAO_0000112 xml:lang="en">the US State Department, the German Bundesgesundheitsministerium, the UK Her Mayesty&apos;s Treasury</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">An organization that is part of the government and that is responsible for managing a specific sector of government.</obo:IAO_0000115>
         <obo:IAO_0000118 xml:lang="en">ministry</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">government department</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">https://en.wikipedia.org/w/index.php?title=Ministry_(government_department)&amp;oldid=755317373</obo:IAO_0000119>
-        <rdfs:label xml:lang="en">government department</rdfs:label>
+        <rdfs:label xml:lang="en">governmental department</rdfs:label>
     </owl:Class>
     
 
@@ -6421,7 +6426,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000275">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000274"/>
-        <obo:IAO_0000115 xml:lang="en">A government department that manages aspects of prevention, healthcare, healthcare administration, and public health.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A governmental department that manages aspects of prevention, healthcare, healthcare administration, and public health.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">department of health</rdfs:label>
     </owl:Class>
@@ -6432,7 +6437,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000276">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000274"/>
-        <obo:IAO_0000115 xml:lang="en">A government department that manages the government of the travel of goods and people in the governed area and the infrastructure related to travel.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A governmental department that manages the government of the travel of goods and people in the governed area and the infrastructure related to travel.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">department of transportation</rdfs:label>
     </owl:Class>
@@ -6443,7 +6448,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000277">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000274"/>
-        <obo:IAO_0000115 xml:lang="en">A government department that manages the government of means to prevent and fight fires and, in some cases, other accidental events and natural disasters.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A governmental department that manages the government of means to prevent and fight fires and, in some cases, other accidental events and natural disasters.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">department of fire administration</rdfs:label>
     </owl:Class>
@@ -6620,8 +6625,9 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000130"/>
         <obo:IAO_0000115 xml:lang="en">A plan specification approval process that has a trauma system plan as specified input and part of the government or part of the machinery of government as an active agent expressing their agreement with the trauma system plan.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
-        <rdfs:comment xml:lang="en">The part of goverment or part of the government machinery can be national, state, or regional.</rdfs:comment>
-        <rdfs:label xml:lang="en">trauma system plan government approval process</rdfs:label>
+        <obo:IAO_0000118 xml:lang="en">trauma system plan government approval process</obo:IAO_0000118>
+        <rdfs:comment xml:lang="en">The part of goverment or part of the governmental machinery can be national, state, or regional.</rdfs:comment>
+        <rdfs:label xml:lang="en">trauma system plan governmental approval process</rdfs:label>
     </owl:Class>
     
 
@@ -6641,7 +6647,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000094"/>
-        <obo:IAO_0000115 xml:lang="en">A trauma system plan specification that is the specified output of a government approval process.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A trauma system plan specification that is the specified output of a governmental approval process.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:comment xml:lang="en">Approval is given on the appropriate level: national, state, or regional.</rdfs:comment>
         <rdfs:label xml:lang="en">government-approved trauma system plan specification</rdfs:label>
@@ -7206,9 +7212,10 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000317">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000271"/>
-        <obo:IAO_0000115 xml:lang="en">A government agency that evaluates healthcare provider organizations, which are candidates for acquiring a trauma center role, and reports as an outcome whether the organization is fit to be a trauma center.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A governmental agency that evaluates healthcare provider organizations, which are candidates for acquiring a trauma center role, and reports as an outcome whether the organization is fit to be a trauma center.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
-        <rdfs:label xml:lang="en">trauma center verification government agency</rdfs:label>
+        <obo:IAO_0000118 xml:lang="en">trauma center verification government agency</obo:IAO_0000118>
+        <rdfs:label xml:lang="en">trauma center verification governmental agency</rdfs:label>
     </owl:Class>
     
 

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -1271,7 +1271,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000020">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0021001"/>
-        <obo:IAO_0000115 xml:lang="en">A document act that creates the role of a trauma center based on meeting the criteria by a designated organization.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A deontic document act that creates the role of a trauma center based on meeting the criteria by a designated organization.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <obo:IAO_0000117 xml:lang="en">Sarah Bost</obo:IAO_0000117>
         <obo:OOSTT_00000030 xml:lang="en">A state, regional, provincial, or national recognition process in which a facility is awarded a trauma center role after a formal review of the hospital&apos;s organization, capacity, personnel, and resources by a verifying agency.</obo:OOSTT_00000030>
@@ -4395,7 +4395,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:IAO_0000115 xml:lang="en">A document act that creates a mutally dependent employee and employer role.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">A deontic document act that creates a mutally dependent employee and employer role.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <obo:OOSTT_00000030 xml:lang="en">A contract specifying the relationship between an employee and employer that outlines specific role responsibilities and expectations.</obo:OOSTT_00000030>
         <rdfs:comment xml:lang="en">JPB (20 March 2017): should output employee role and employer role</rdfs:comment>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -297,7 +297,7 @@ https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/RO_0000056"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/BFO_0000004"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/>
-        <obo:IAO_0000115 xml:lang="en">&apos;Organize&apos; holds between an independent continuant and a planned process, iff the independent continuant particpates in the planned process and also participated in the creation of the plan specification that the planned process realizes.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">&apos;organize&apos; holds between an independent continuant and a planned process, iff the independent continuant particpates in the planned process and also participated in the creation of the plan specification that the planned process realizes.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">organize</rdfs:label>
     </owl:ObjectProperty>
@@ -334,7 +334,7 @@ https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_
         <owl:inverseOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000278"/>
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/IAO_0000033"/>
-        <obo:IAO_0000115 xml:lang="en">&apos;Has policy&apos; holds between an organization and a directive information entity, iff the directive information entity is the outcome of a document act and it is meant to regulate the actions of the organization or its organizational members.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">&apos;has policy&apos; holds between an organization and a directive information entity, iff the directive information entity is the outcome of a document act and it is meant to regulate the actions of the organization or its organizational members.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">has policy</rdfs:label>
     </owl:ObjectProperty>
@@ -346,7 +346,7 @@ https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000145">
         <rdfs:domain rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
         <rdfs:range rdf:resource="http://purl.obolibrary.org/obo/GEO_000000372"/>
-        <obo:IAO_0000115 xml:lang="en">&apos;Services area&apos; holds iff a an organization performing or organizing paid or unpaid planned processes that benefit 3rd parties and b is a geographical region and a performs or organizes said planned process in the site of b.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">&apos;services area&apos; holds iff a an organization performing or organizing paid or unpaid planned processes that benefit 3rd parties and b is a geographical region and a performs or organizes said planned process in the site of b.</obo:IAO_0000115>
         <obo:IAO_0000117>Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">services geographical region</rdfs:label>
     </owl:ObjectProperty>
@@ -356,7 +356,7 @@ https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_
     <!-- http://purl.obolibrary.org/obo/OOSTT_00000278 -->
 
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000278">
-        <obo:IAO_0000115 xml:lang="en">&apos;Policy of&apos; holds between a directive information entity and an organization iff the directive information entity is the outcome of a document act and it is meant to regulate the actions of the organization or its organizational members.</obo:IAO_0000115>
+        <obo:IAO_0000115 xml:lang="en">&apos;policy of&apos; holds between a directive information entity and an organization iff the directive information entity is the outcome of a document act and it is meant to regulate the actions of the organization or its organizational members.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">policy of</rdfs:label>
     </owl:ObjectProperty>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -29,7 +29,7 @@
         <dc:contributor xml:lang="en">Stephen M. Bowman</dc:contributor>
         <dc:contributor xml:lang="en">William R. Hogan</dc:contributor>
         <dc:creator xml:lang="en">Mathias Brochhausen</dc:creator>
-        <dc:license rdf:datatype="http://www.w3.org/2001/XMLSchema#string">http://creativecommons.org/licenses/by/4.0/</dc:license>
+        <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
         <dc:title xml:lang="en">Ontology of Organizational Structures of Trauma centers and Trauma Systems</dc:title>
         <rdfs:comment xml:lang="en">Development of this ontology is funded by a grant from the National Institute of General Medical Sciences of the National Institutes of Health.</rdfs:comment>
         <owl:versionInfo xml:lang="en">development version - 2021-01-11</owl:versionInfo>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -1719,6 +1719,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
         <obo:IAO_0000115 xml:lang="en">A committee with members from multiple specialties that engages in case review of trauma cases.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+        <obo:IAO_0100001>trauma multidisciplinary peer review committee (OOSTT_00000006)</obo:IAO_0100001>
         <obo:OOSTT_00000030 xml:lang="en">A committee with members from multiple specialties that engages in case review of trauma cases.</obo:OOSTT_00000030>
         <rdfs:label xml:lang="en">obsolete_trauma peer review committee</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
@@ -2686,6 +2687,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
         <obo:IAO_0000115 xml:lang="en">Government is the means by which policy within a community are enforced, as well as the mechanism for determining the policy of the community.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">J. Neil Otte</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">https://en.wikipedia.org/w/index.php?title=Government&amp;oldid=727121222</obo:IAO_0000119>
+        <obo:IAO_0100001>government (http://www.ontologyrepository.com/CommonCoreOntologies/Government)</obo:IAO_0100001>
         <rdfs:comment xml:lang="en">the community may be local, regional, state, or national (Comment provided by J. Ball, N. Sanddal, S. Bowman) - 2017-07-18</rdfs:comment>
         <rdfs:label xml:lang="en">obsolete_government</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
@@ -3070,6 +3072,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
         <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000115 xml:lang="en">A plan specification that specifies on which schedule and to which extent anesthesia services are provided within a healthcare provider organization.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
+        <obo:IAO_0100001>anesthesia services availability plan specification (OOSTT_00000375)</obo:IAO_0100001>
         <obo:OOSTT_00000030 xml:lang="en">A plan that specifies the schedule for ensuring adequate numbers of  anesthesia care providers are readily available 24 hours a day 7 days a week within a trauma center.</obo:OOSTT_00000030>
         <rdfs:label xml:lang="en">obsolete_anesthesia services availability plan specification</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -30,8 +30,8 @@
         <dc:contributor xml:lang="en">William R. Hogan</dc:contributor>
         <dc:creator xml:lang="en">Mathias Brochhausen</dc:creator>
         <dc:description>The Ontology of Organizational Structures of Trauma centers and Trauma systems (OOSTT) is a representation of the components of trauma centers and trauma systems coded in Web Ontology Language (OWL2).</dc:description>
-        <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
         <dc:title xml:lang="en">Ontology of Organizational Structures of Trauma centers and Trauma Systems</dc:title>
+        <terms:license rdf:resource="http://creativecommons.org/licenses/by/4.0/"/>
         <rdfs:comment xml:lang="en">Development of this ontology is funded by a grant from the National Institute of General Medical Sciences of the National Institutes of Health.</rdfs:comment>
         <owl:versionInfo xml:lang="en">development version - 2021-01-11</owl:versionInfo>
     </owl:Ontology>
@@ -2682,12 +2682,13 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
     <!-- http://purl.obolibrary.org/obo/OOSTT_00000112 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000112">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
+        <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
         <obo:IAO_0000115 xml:lang="en">Government is the means by which policy within a community are enforced, as well as the mechanism for determining the policy of the community.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">J. Neil Otte</obo:IAO_0000117>
         <obo:IAO_0000119 xml:lang="en">https://en.wikipedia.org/w/index.php?title=Government&amp;oldid=727121222</obo:IAO_0000119>
         <rdfs:comment xml:lang="en">the community may be local, regional, state, or national (Comment provided by J. Ball, N. Sanddal, S. Bowman) - 2017-07-18</rdfs:comment>
-        <rdfs:label xml:lang="en">government</rdfs:label>
+        <rdfs:label xml:lang="en">obsolete_government</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -4672,7 +4673,6 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
     <!-- http://purl.obolibrary.org/obo/OOSTT_00000201 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000201">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000023"/>
         <owl:equivalentClass>
             <owl:Class>
                 <owl:intersectionOf rdf:parseType="Collection">
@@ -4715,6 +4715,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
                 </owl:intersectionOf>
             </owl:Class>
         </owl:equivalentClass>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000023"/>
         <obo:IAO_0000115 xml:lang="en">A collection of humans that consists only of bearers of a trauma surgeon role that are mentioned in a trauma on call plan specification and that particpates in practice based training course organized by a trauma program.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <obo:IAO_0000117 xml:lang="en">Sarah Bost</obo:IAO_0000117>
@@ -6327,7 +6328,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
                                     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000271"/>
                                     <owl:Restriction>
                                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000112"/>
+                                        <owl:someValuesFrom rdf:resource="http://www.ontologyrepository.com/CommonCoreOntologies/Government"/>
                                     </owl:Restriction>
                                     <owl:Restriction>
                                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000846"/>
@@ -6384,7 +6385,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000846"/>
-                <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000112"/>
+                <owl:someValuesFrom rdf:resource="http://www.ontologyrepository.com/CommonCoreOntologies/Government"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <obo:IAO_0000112 xml:lang="en">the US State Department, the German Bundesgesundheitsministerium, the UK Her Mayesty&apos;s Treasury</obo:IAO_0000112>
@@ -6422,8 +6423,8 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000277">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000274"/>
-        <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <obo:IAO_0000115 xml:lang="en">A government department that manages the government of means to prevent and fight fires and, in some cases, other accidental events and natural disasters.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">department of fire administration</rdfs:label>
     </owl:Class>
     
@@ -6583,11 +6584,11 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
                                 <owl:unionOf rdf:parseType="Collection">
                                     <owl:Restriction>
                                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000112"/>
+                                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000270"/>
                                     </owl:Restriction>
                                     <owl:Restriction>
                                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000050"/>
-                                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000270"/>
+                                        <owl:someValuesFrom rdf:resource="http://www.ontologyrepository.com/CommonCoreOntologies/Government"/>
                                     </owl:Restriction>
                                 </owl:unionOf>
                             </owl:Class>
@@ -7597,8 +7598,8 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
             </owl:Restriction>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000367"/>
-        <obo:IAO_0000117 xml:lang="en">Joseph Utecht</obo:IAO_0000117>
         <obo:IAO_0000115 xml:lang="en">A physician who has completed an neurosurgery residency program and achieved board certification.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Joseph Utecht</obo:IAO_0000117>
         <obo:OOSTT_00000030 xml:lang="en">A physician who has completed an neurosurgery residency program and achieved board certification.</obo:OOSTT_00000030>
         <rdfs:label xml:lang="en">board certified neurosurgeon role</rdfs:label>
     </owl:Class>
@@ -7961,6 +7962,26 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
         <obo:IAO_0000116 xml:lang="en">A part of graduate education where the graduate from a medical program practices medicine under the supervision of an attending physician. (OOSTT editor comment created by M. Brochhausen, Nov 9, 2016)</obo:IAO_0000116>
         <dc:source>http://vivoweb.org/sites/vivoweb.org/files/vivo-isf-public-1.6.owl</dc:source>
         <rdfs:label xml:lang="en">Medical Residency</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://www.ontologyrepository.com/CommonCoreOntologies/Government -->
+
+    <owl:Class rdf:about="http://www.ontologyrepository.com/CommonCoreOntologies/Government">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000245"/>
+        <obo:IAO_0000115 xml:lang="en">An Organization that exercises executive, legislative, or judicial authority over a Geopolitical Entity.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">https://en.wikipedia.org/wiki/Government</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">is curated in ontology: http://www.ontologyrepository.com/CommonCoreOntologies/Mid/AgentOntology</obo:IAO_0000116>
+        <obo:IAO_0000412 rdf:resource="http://www.ontologyrepository.com/CommonCoreOntologies/Government"/>
+        <dc:date xml:lang="en">Imported 8.30.2018</dc:date>
+        <dc:license xml:lang="en">BSD 3-Clause License
+
+Copyright (c) 2017, CUBRC, Inc.
+All rights reserved.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</dc:license>
+        <rdfs:label xml:lang="en">government</rdfs:label>
     </owl:Class>
     
 

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -6419,7 +6419,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000277">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000274"/>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
-        <obo:IAO_0000119 xml:lang="en">A government department that manages the government of means to prevent and fight fires and, in some cases, other accidental events and natural disasters.</obo:IAO_0000119>
+        <obo:IAO_0000115 xml:lang="en">A government department that manages the government of means to prevent and fight fires and, in some cases, other accidental events and natural disasters.</obo:IAO_0000115>
         <rdfs:label xml:lang="en">department of fire administration</rdfs:label>
     </owl:Class>
     
@@ -6507,7 +6507,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000282">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/BFO_0000023"/>
-        <obo:IAO_0000117 xml:lang="en">A role borne by a human healthcare provider that, if realized is realized by managing and coordinating the operations a trauma system and its evaluation.</obo:IAO_0000117>
+        <obo:IAO_0000115 xml:lang="en">A role borne by a human healthcare provider that, if realized is realized by managing and coordinating the operations a trauma system and its evaluation.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">trauma system manager role</rdfs:label>
     </owl:Class>
@@ -6891,7 +6891,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000303">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000301"/>
-        <obo:IAO_0000117 xml:lang="en">An emergency medical services pediatric transportation agency that provides air transportation.</obo:IAO_0000117>
+        <obo:IAO_0000115 xml:lang="en">An emergency medical services pediatric transportation agency that provides air transportation.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">emergency medical services pediatric air transportation agency</rdfs:label>
     </owl:Class>
@@ -6996,7 +6996,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000308">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000306"/>
-        <obo:IAO_0000117 xml:lang="en">A healthcare provider organization role that is borne by a hospital and that gets assigned based on an evaluation process. If realized, the role is realized by the hospital providing a burns managment team and providing state-of-the-art specialized pediatric burn treatment and recovery.</obo:IAO_0000117>
+        <obo:IAO_0000115 xml:lang="en">A healthcare provider organization role that is borne by a hospital and that gets assigned based on an evaluation process. If realized, the role is realized by the hospital providing a burns managment team and providing state-of-the-art specialized pediatric burn treatment and recovery.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">pediatric burn center role</rdfs:label>
     </owl:Class>
@@ -7061,7 +7061,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000311">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000015"/>
-        <obo:IAO_0000117 xml:lang="en">A role borne by an organization and realized by providing specialized rehabilitation for patients with traumatic brain injuries.</obo:IAO_0000117>
+        <obo:IAO_0000115 xml:lang="en">A role borne by an organization and realized by providing specialized rehabilitation for patients with traumatic brain injuries.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">traumatic brain injury rehabilitation organization role</rdfs:label>
     </owl:Class>
@@ -7099,7 +7099,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000313">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000015"/>
-        <obo:IAO_0000117 xml:lang="en">A role borne by a hospital and realized by providing specialized care for patients with spinal cord injuries.</obo:IAO_0000117>
+        <obo:IAO_0000115 xml:lang="en">A role borne by a hospital and realized by providing specialized care for patients with spinal cord injuries.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
         <rdfs:label xml:lang="en">spinal cord injury center role</rdfs:label>
     </owl:Class>
@@ -7588,6 +7588,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000367"/>
         <obo:IAO_0000117 xml:lang="en">Joseph Utecht</obo:IAO_0000117>
+        <obo:IAO_0000115 xml:lang="en">A physician who has completed an neurosurgery residency program and achieved board certification.</obo:IAO_0000115>
         <obo:OOSTT_00000030 xml:lang="en">A physician who has completed an neurosurgery residency program and achieved board certification.</obo:OOSTT_00000030>
         <rdfs:label xml:lang="en">board certified neurosurgeon role</rdfs:label>
     </owl:Class>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -1715,11 +1715,13 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
     <!-- http://purl.obolibrary.org/obo/OOSTT_00000052 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000052">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000114"/>
-        <obo:IAO_0000115 xml:lang="en">A committee that engages in case review of trauma cases.</obo:IAO_0000115>
+        <rdfs:subClassOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#ObsoleteClass"/>
+        <obo:IAO_0000115 xml:lang="en">A committee with members from multiple specialties that engages in case review of trauma cases.</obo:IAO_0000115>
         <obo:IAO_0000117 xml:lang="en">Mathias Brochhausen</obo:IAO_0000117>
-        <obo:OOSTT_00000030 xml:lang="en">A committee that engages in case review of trauma care.</obo:OOSTT_00000030>
-        <rdfs:label xml:lang="en">trauma peer review committee</rdfs:label>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+        <obo:OOSTT_00000030 xml:lang="en">A committee with members from multiple specialties that engages in case review of trauma cases.</obo:OOSTT_00000030>
+        <rdfs:label xml:lang="en">obsolete_trauma peer review committee</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -1739,13 +1739,15 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000054">
         <owl:equivalentClass>
-            <owl:intersectionOf rdf:parseType="Collection">
-                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000011"/>
-                <owl:Restriction>
-                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000299"/>
-                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000159"/>
-                </owl:Restriction>
-            </owl:intersectionOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000011"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000299"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000159"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OBI_0000011"/>
         <obo:IAO_0000115 xml:lang="en">A planned process that has prehospital protocols as its specified output.</obo:IAO_0000115>
@@ -3690,13 +3692,15 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000166">
         <owl:equivalentClass>
-            <owl:intersectionOf rdf:parseType="Collection">
-                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/>
-                <owl:Restriction>
-                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
-                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000167"/>
-                </owl:Restriction>
-            </owl:intersectionOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000167"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
         <rdfs:subClassOf>
@@ -4967,13 +4971,15 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000212">
         <owl:equivalentClass>
-            <owl:intersectionOf rdf:parseType="Collection">
-                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000288"/>
-                <owl:Restriction>
-                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
-                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000211"/>
-                </owl:Restriction>
-            </owl:intersectionOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000288"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000211"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000288"/>
         <obo:IAO_0000115 xml:lang="en">An information content entity that is the specified output of a critical care certificate course.</obo:IAO_0000115>
@@ -5044,13 +5050,15 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000215">
         <owl:equivalentClass>
-            <owl:intersectionOf rdf:parseType="Collection">
-                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/>
-                <owl:Restriction>
-                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
-                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000214"/>
-                </owl:Restriction>
-            </owl:intersectionOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000214"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
         <rdfs:subClassOf>
@@ -5649,13 +5657,15 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000233">
         <owl:equivalentClass>
-            <owl:intersectionOf rdf:parseType="Collection">
-                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/>
-                <owl:Restriction>
-                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
-                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000232"/>
-                </owl:Restriction>
-            </owl:intersectionOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000030"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000312"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000232"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000030"/>
         <rdfs:subClassOf>
@@ -6773,13 +6783,15 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000296">
         <owl:equivalentClass>
-            <owl:intersectionOf rdf:parseType="Collection">
-                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
-                <owl:Restriction>
-                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000075"/>
-                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000292"/>
-                </owl:Restriction>
-            </owl:intersectionOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000075"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000292"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
         <obo:IAO_0000115 xml:lang="en">An aggregate of emergency medical services agencies that provide transport for the sick and injured.</obo:IAO_0000115>
@@ -6894,13 +6906,15 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000304">
         <owl:equivalentClass>
-            <owl:intersectionOf rdf:parseType="Collection">
-                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
-                <owl:Restriction>
-                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000075"/>
-                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000302"/>
-                </owl:Restriction>
-            </owl:intersectionOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000075"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000302"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
         <obo:IAO_0000115 xml:lang="en">An aggregate of organization that consists only of emergency medical service pediatric ground transportation agencies.</obo:IAO_0000115>
@@ -6914,13 +6928,15 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OOSTT_00000305">
         <owl:equivalentClass>
-            <owl:intersectionOf rdf:parseType="Collection">
-                <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
-                <owl:Restriction>
-                    <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000075"/>
-                    <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000303"/>
-                </owl:Restriction>
-            </owl:intersectionOf>
+            <owl:Class>
+                <owl:intersectionOf rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
+                    <owl:Restriction>
+                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/BFO_0000075"/>
+                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000303"/>
+                    </owl:Restriction>
+                </owl:intersectionOf>
+            </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/OMRSE_00000033"/>
         <obo:IAO_0000115 xml:lang="en">An aggregate of organization that consists only of emergency medical service pediatric air transportation agencies.</obo:IAO_0000115>

--- a/development/oostt.owl
+++ b/development/oostt.owl
@@ -2681,7 +2681,7 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
                     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000245"/>
                     <owl:Restriction>
                         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/OBI_0000846"/>
-                        <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/OOSTT_00000112"/>
+                        <owl:someValuesFrom rdf:resource="http://www.ontologyrepository.com/CommonCoreOntologies/Government"/>
                     </owl:Restriction>
                 </owl:intersectionOf>
             </owl:Class>
@@ -6414,8 +6414,8 @@ A patient suffering one or more injuries.</obo:IAO_0000119>
         </rdfs:subClassOf>
         <obo:IAO_0000112 xml:lang="en">the US State Department, the German Bundesgesundheitsministerium, the UK Her Mayesty&apos;s Treasury</obo:IAO_0000112>
         <obo:IAO_0000115 xml:lang="en">An organization that is part of the government and that is responsible for managing a specific sector of government.</obo:IAO_0000115>
-        <obo:IAO_0000118 xml:lang="en">ministry</obo:IAO_0000118>
         <obo:IAO_0000118 xml:lang="en">government department</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">ministry</obo:IAO_0000118>
         <obo:IAO_0000119 xml:lang="en">https://en.wikipedia.org/w/index.php?title=Ministry_(government_department)&amp;oldid=755317373</obo:IAO_0000119>
         <rdfs:label xml:lang="en">governmental department</rdfs:label>
     </owl:Class>


### PR DESCRIPTION
The following changes address issues identified by the OBO Dashboard and a review from Bill Hogan.  Notes taken from commit messages:

Updating license annotation

Fixing duplicate definitions.
Edited definitions for:
OOSTT_00000161 'aggregate of level 2 trauma centers'
OOSTT_00000305 'aggregate of emergency medical services pediatric air transportation agencies'

Added description (for OOSTT)

Fixed lowercase definitions.

Added superclass to OOSTT_00000201 'collection of trauma surgeons on trauma service with practice-based learning course'

Removed duplicate alternative term for OOSTT_00000089 'surgeon role'

Added genus to equivalent class for following terms:
OOSTT_00000054 'hospital role'
OOSTT_00000166 'successful completion of ATLS course information content entity'
OOSTT_00000212 'critical care certificate'
OOSTT_00000215 'successful completion of trauma surgery fellowship information content entity'
OOSTT_00000233 'successful completion of anesthesiology residency information content entity'
OOSTT_00000296 'aggregate of emergency medical service transporting agency'
OOSTT_00000304 'aggregate of emergency medical services pediatric ground transportation agencies'
OOSTT_00000305 'aggregate of emergency medical services pediatric air transportation agencies'

Corrected definition tag on following terms:
OOSTT_00000277 'department of fire administration'
OOSTT_00000282 'trauma system manager role'
OOSTT_00000303 'emergency medical services pediatric air transportation agency'
OOSTT_00000308 'pediatric burn center role'
OOSTT_00000311 'traumatic brain injury rehabilitation organization role'
OOSTT_00000313 'spinal cord injury center role'
OOSTT_00000365 'board certified neurosurgeon role'

Removed unused import of IAO_0020012 'obsolete_designates'

Spelling fix

Replacing references to obsolete OOSTT_00000208 'obsolete_on call exclusivity obligee role'
with OOSTT_00000372 'on call exclusivity obligor role'

obsoleted 'trauma peer review committee'
OOSTT_00000052

Reversed obselete on 'anesthesia services availability plan specification'
New term OOSTT_00000375 created
References to old term OOSTT_00000133 replaced with OOSTT_00000375

Replaced 'government' with imported term.
Obsoleted OOSTT_00000112 'government'.
Imported CommonCoreOntologies/Government.
Replaced references to OOSTT_00000112 with new term.

Added 'term replaced by' for the following obsolete classes:
OOSTT_00000052 'obsolete_trauma peer review committee'
OOSTT_00000133 'obsolete_anesthesia services availability plan specification'
OOSTT_00000112 'obsolete_government'

Added definitions for the following properties:
OOSTT_00000030 'OOSTT user-centered description'
OOSTT_00000113 'prescribes'

Edited definition of 'ratifying regulations for trauma system'.
OOSTT_00000279

Edited definitions for:
OOSTT_00000190 'employment contract document act'
OOSTT_00000020 'trauma center designation'

For consistency, all uses of government as an adjective
have been updated to 'governmental.'  Alternate labels provided for any label changes.
Affected terms:
OOSTT_00000111 'governmental organization'
OOSTT_00000127 'emergency department'
OOSTT_00000271 'governmental agency'
OOSTT_00000272 'non-governmental organization'
OOSTT_00000273 'free-standing governmental agency'
OOSTT_00000274 'governmental department'
OOSTT_00000275 'department of health'
OOSTT_00000276 'department of transportation'
OOSTT_00000277 'department of fire administration'
OOSTT_00000286 'trauma system plan governmental approval process'
OOSTT_00000287 'government-approved trauma system plan specification'
OOSTT_00000317 'trauma center verification governmental agency'

Correcting OOSTT_00000111 'governmental organization'
to  use correct 'government' in equivalence class.
